### PR TITLE
Remove a hard dependency on the Unix module

### DIFF
--- a/lib/conv.ml
+++ b/lib/conv.ml
@@ -590,13 +590,6 @@ let () =
         | Sys.Break -> Atom "Sys.Break"
         | _ -> assert false)
       );(
-        Unix.Unix_error (Unix.E2BIG, "", ""),
-        (function
-        | Unix.Unix_error (err, loc, arg) ->
-            let err_str = Unix.error_message err in
-            List [Atom "Unix.Unix_error"; Atom err_str; Atom loc; Atom arg]
-        | _ -> assert false)
-      );(
         Of_sexp_error (Exit, Atom ""),
         (function
         | Of_sexp_error (exc, sexp) ->


### PR DESCRIPTION
This removes an exception printer which requires Unix to be linked
to use Sexp.  Without this, there is only a "soft" dependency in
the form of Bigarray, which doesn't require unix.cmxa to actually
be present.

It would be great if this exception printer could be moved into a
sexplib.unix subpackage, to make it easier to portably use it
in Mirage or JavaScript.
