### PR TITLE
pass -Wno-invalid-pp-token to cpp to make clang happy

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,6 +1,6 @@
 # OASIS_START
 # OASIS_STOP
-<lib/pre_sexp.ml>: pp(cpp -undef -traditional -Isyntax)
+<lib/pre_sexp.ml>: pp(cpp -undef -traditional -Isyntax -Wno-invalid-pp-token)
 <lib_test/*.ml{,i}>: syntax_camlp4o
 <syntax/pa_sexp_conv.ml>: syntax_camlp4o
 "top/sexplib_install_printers.ml": I(+compiler-libs)


### PR DESCRIPTION
otherwise, the resulting depends file will be empty and the build fails

fixes #5
