### PR TITLE
RFC: Js of ocaml

### DIFF
--- a/lib/pre_sexp.ml
+++ b/lib/pre_sexp.ml
@@ -744,7 +744,10 @@ let mk_cont_parser cont_parse = (); fun _state str ~max_pos ~pos ->
       | '"' -> \
           bump_found_atom \
             bump_text_pos state str ~max_pos ~pos reg_parse_quoted \
-      | c -> add_bump_pos state str ~max_pos ~pos c parse_atom \
+      | c -> \
+            Buffer.add_char state.pbuf c; \
+            bump_text_pos state; \
+            parse_atom state str ~max_pos ~pos:(pos + 1) \
   \
   and maybe_parse_bad_atom_pipe state str ~max_pos ~pos = \
     if pos > max_pos then \
@@ -789,8 +792,10 @@ let mk_cont_parser cont_parse = (); fun _state str ~max_pos ~pos ->
               bump_pos_cont state str ~max_pos ~pos PARSE) \
       | '\\' -> bump_pos_cont state str ~max_pos ~pos parse_escaped \
       | '\010' as c -> add_bump_line state str ~max_pos ~pos c parse_quoted \
-      | c -> add_bump_pos state str ~max_pos ~pos c parse_quoted \
-  \
+      | c -> \
+          Buffer.add_char state.pbuf c; \
+          bump_text_pos state; \
+          parse_quoted state str ~max_pos ~pos:(pos + 1) \
   and parse_escaped state str ~max_pos ~pos = \
     if pos > max_pos then mk_cont "parse_escaped" parse_escaped state \
     else \

--- a/opam
+++ b/opam
@@ -1,0 +1,20 @@
+opam-version: "1"
+version: "111.25.00"
+maintainer: "opensource@janestreet.com"
+build: [
+  ["./configure" "--%{type_conv:enable}%-syntax"]
+  [make]
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "sexplib"]
+  ["ocamlfind" "remove" "sexplib_num"]
+  ["ocamlfind" "remove" "sexplib_unix"]
+]
+depends: ["ocamlfind"]
+depopts: ["camlp4" "type_conv"]
+conflicts: [
+  "type_conv" {< "111.13.00"}
+  "type_conv" {> "111.13.00"}
+]
+ocaml-version: [>= "4.00.0"]


### PR DESCRIPTION
On Firefox (with `js_of_ocaml`), I sometimes get "Stack overflow" errors parsing sexprs. It looks like `js_of_ocaml` can't see that the parser is tail recursive. This patch fixes it for me by inlining the helpers for processing string and atom characters. Ideally, it should be fixed properly for all cases, but in my application the rest of the structure is a fixed length so it doesn't affect me.

The bug doesn't always appear, even on the same input, so might depend on exactly what the JIT is doing. However, this reliably fails for me without the patch:

    open Sexplib.Sexp

    let () =
      let item =
	"\"x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x\""
      in
      let parsed : t =
	match parse item with
	| Done (parsed, _pos) -> parsed
	| Cont _ -> assert false in
      ignore parsed;
      print_endline "success"

If it passes for you, a longer string might trigger it better.