### PR TITLE
Add support for OCaml 5.00

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
-(library (name sexplib) (libraries bigarray parsexp sexplib0)
+(library (name sexplib) (libraries bigarray-compat parsexp sexplib0)
  (public_name sexplib) (preprocess no_preprocessing))
 
 (ocamllex lexer)

--- a/src/exn_magic.ml
+++ b/src/exn_magic.ml
@@ -1,11 +1,5 @@
-module Extension_constructor = struct
-  [@@@ocaml.warning "-3"]
-
-  let of_val = Obj.extension_constructor
-end
-
 let register exc exc_name =
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun _exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun _exc ->
     Sexp.Atom exc_name)
 ;;
 
@@ -13,7 +7,7 @@ let magic_field repr n = Obj.magic (Obj.field repr n)
 
 let register1 make_exc exc_name sexp_of_arg1 =
   let exc = make_exc (Obj.magic None) in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     Sexp.List [ Sexp.Atom exc_name; sexp1 ])
@@ -21,7 +15,7 @@ let register1 make_exc exc_name sexp_of_arg1 =
 
 let register2 make_exc exc_name sexp_of_arg1 sexp_of_arg2 =
   let exc = make_exc (Obj.magic None) (Obj.magic None) in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     let sexp2 = sexp_of_arg2 (magic_field repr 2) in
@@ -30,7 +24,7 @@ let register2 make_exc exc_name sexp_of_arg1 sexp_of_arg2 =
 
 let register3 make_exc exc_name sexp_of_arg1 sexp_of_arg2 sexp_of_arg3 =
   let exc = make_exc (Obj.magic None) (Obj.magic None) (Obj.magic None) in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     let sexp2 = sexp_of_arg2 (magic_field repr 2) in
@@ -42,7 +36,7 @@ let register4 make_exc exc_name sexp_of_arg1 sexp_of_arg2 sexp_of_arg3 sexp_of_a
   let exc =
     make_exc (Obj.magic None) (Obj.magic None) (Obj.magic None) (Obj.magic None)
   in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     let sexp2 = sexp_of_arg2 (magic_field repr 2) in
@@ -68,7 +62,7 @@ let register5
       (Obj.magic None)
       (Obj.magic None)
   in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     let sexp2 = sexp_of_arg2 (magic_field repr 2) in
@@ -97,7 +91,7 @@ let register6
       (Obj.magic None)
       (Obj.magic None)
   in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     let sexp2 = sexp_of_arg2 (magic_field repr 2) in
@@ -129,7 +123,7 @@ let register7
       (Obj.magic None)
       (Obj.magic None)
   in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     let sexp2 = sexp_of_arg2 (magic_field repr 2) in
@@ -164,7 +158,7 @@ let register8
       (Obj.magic None)
       (Obj.magic None)
   in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     let sexp2 = sexp_of_arg2 (magic_field repr 2) in
@@ -203,7 +197,7 @@ let register9
       (Obj.magic None)
       (Obj.magic None)
   in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     let sexp2 = sexp_of_arg2 (magic_field repr 2) in
@@ -255,7 +249,7 @@ let register10
       (Obj.magic None)
       (Obj.magic None)
   in
-  Conv.Exn_converter.add (Extension_constructor.of_val exc) (fun exc ->
+  Conv.Exn_converter.add (Obj.Extension_constructor.of_val exc) (fun exc ->
     let repr = Obj.repr exc in
     let sexp1 = sexp_of_arg1 (magic_field repr 1) in
     let sexp2 = sexp_of_arg2 (magic_field repr 2) in


### PR DESCRIPTION
Not ready to be merged. Only works for OCaml >= 4.14
Will depend on whatever is going to be accepted for https://github.com/janestreet/sexplib0/pull/8 and https://github.com/janestreet/base/pull/127